### PR TITLE
Fix 1.21+ support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     // Dependencies that we want to shade in
     implementation("com.iridium", "IridiumCore", "2.0.9")
     implementation("org.bstats", "bstats-bukkit", "3.1.0")
+    implementation("org.apache.commons", "commons-text", "1.13.1")
     implementation("com.j256.ormlite", "ormlite-core", "6.1")
     implementation("com.j256.ormlite", "ormlite-jdbc", "6.1")
     implementation("de.jeff_media", "SpigotUpdateChecker", "1.3.2")

--- a/src/main/java/com/iridium/iridiummobcoins/listeners/EntityDeathListener.java
+++ b/src/main/java/com/iridium/iridiummobcoins/listeners/EntityDeathListener.java
@@ -3,7 +3,7 @@ package com.iridium.iridiummobcoins.listeners;
 import com.iridium.iridiumcore.utils.StringUtils;
 import com.iridium.iridiummobcoins.IridiumMobCoins;
 import com.iridium.iridiummobcoins.database.User;
-import org.apache.commons.lang.WordUtils;
+import org.apache.commons.text.WordUtils;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;


### PR DESCRIPTION
Modern Minecraft versions no longer seem to have commons-lang as a dependency (and it has been superseeded by commons-text in this specific case anyway). This causes the plugin to not work properly, which this PR addresses.