### PR TITLE
Hide empty mobcoin receive messages

### DIFF
--- a/src/main/java/com/iridium/iridiummobcoins/listeners/EntityDeathListener.java
+++ b/src/main/java/com/iridium/iridiummobcoins/listeners/EntityDeathListener.java
@@ -23,14 +23,14 @@ public class EntityDeathListener implements Listener {
             double random = Math.floor(Math.random() * 100) + 1;
             if (random <= mobCoinDropChances.get(event.getEntityType())) {
                 int amount = IridiumMobCoins.getInstance().getConfiguration().mobCoinDropAmounts.getOrDefault(event.getEntityType(), 1);
+                User user = IridiumMobCoins.getInstance().getDatabaseManager().getUser(killer.getUniqueId());
+                user.setMobcoins(user.getMobcoins() + amount);
+
                 String message = StringUtils.color(IridiumMobCoins.getInstance().getMessages().receivedMobCoinFromKillingMob
                         .replace("%prefix%", IridiumMobCoins.getInstance().getConfiguration().prefix)
                         .replace("%entity%", WordUtils.capitalizeFully(event.getEntityType().name().toLowerCase().replace("_", " ")))
                         .replace("%amount%", String.valueOf(amount))
                 );
-                User user = IridiumMobCoins.getInstance().getDatabaseManager().getUser(killer.getUniqueId());
-                user.setMobcoins(user.getMobcoins() + amount);
-
                 if (!message.isEmpty()) {
                     killer.sendMessage(message);
                 }

--- a/src/main/java/com/iridium/iridiummobcoins/listeners/EntityDeathListener.java
+++ b/src/main/java/com/iridium/iridiummobcoins/listeners/EntityDeathListener.java
@@ -23,13 +23,17 @@ public class EntityDeathListener implements Listener {
             double random = Math.floor(Math.random() * 100) + 1;
             if (random <= mobCoinDropChances.get(event.getEntityType())) {
                 int amount = IridiumMobCoins.getInstance().getConfiguration().mobCoinDropAmounts.getOrDefault(event.getEntityType(), 1);
-                killer.sendMessage(StringUtils.color(IridiumMobCoins.getInstance().getMessages().receivedMobCoinFromKillingMob
+                String message = StringUtils.color(IridiumMobCoins.getInstance().getMessages().receivedMobCoinFromKillingMob
                         .replace("%prefix%", IridiumMobCoins.getInstance().getConfiguration().prefix)
                         .replace("%entity%", WordUtils.capitalizeFully(event.getEntityType().name().toLowerCase().replace("_", " ")))
                         .replace("%amount%", String.valueOf(amount))
-                ));
+                );
                 User user = IridiumMobCoins.getInstance().getDatabaseManager().getUser(killer.getUniqueId());
                 user.setMobcoins(user.getMobcoins() + amount);
+
+                if (!message.isEmpty()) {
+                    killer.sendMessage(message);
+                }
             }
         }
     }


### PR DESCRIPTION
Admins may opt to make gaining mobcoins a more passive process and therefore want to hide the message. Doing this unfortunately results in blank lines in chat.